### PR TITLE
Bugfix/add field

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "crypto-js": "^3.1.9-1",
     "dataloader": "^1.4.0",
     "deepmerge": "^1.2.0",
-    "dot-object": "^1.7.0",
     "enzyme-adapter-react-16": "^1.14.0",
     "escape-string-regexp": "^1.0.5",
     "express": "^4.17.1",

--- a/packages/vulcan-lib/lib/modules/collections.js
+++ b/packages/vulcan-lib/lib/modules/collections.js
@@ -75,6 +75,7 @@ Mongo.Collection.prototype.attachSchema = function(schemaOrFields) {
 /**
  * @summary Add an additional field (or an array of fields) to a schema.
  * @param {Object|Object[]} fieldOrFieldArray
+ *
  */
 Mongo.Collection.prototype.addField = function(fieldOrFieldArray) {
   const collection = this;
@@ -87,8 +88,14 @@ Mongo.Collection.prototype.addField = function(fieldOrFieldArray) {
     fieldSchema[field.fieldName] = field.fieldSchema;
   });
 
+  // NOTE: attachSchema will update the schema but
+  // not collection.options, leading to discrepencies
+  // Instead extendCollection will recreate the collection
+  // from start with the right schema
+  // It's slightly slower but guaranteed to work
+  extendCollection(collection, { schema: fieldSchema });
   // add field schema to collection schema
-  collection.attachSchema(createSchema(merge(collection.simpleSchema()._schema, fieldSchema)));
+  //collection.attachSchema(createSchema(merge(collection.simpleSchema()._schema, fieldSchema)));
 };
 
 /**


### PR DESCRIPTION
@EloyID  it should make "addField" more consistent with "extendCollection" and avoid the weird issue when we use both. Under the hood, "addField" is just "extendCollection(collection, {schema})" so from now on you might want to use `extendCollection` only (try to call it only once per package to avoid extra computation on app startup + split between client and server when you have `resolveAs`, si `computedPermissions` for example in the platform)